### PR TITLE
Update CashRegister.cs

### DIFF
--- a/ColesStopAndShop/CashRegister.cs
+++ b/ColesStopAndShop/CashRegister.cs
@@ -225,6 +225,7 @@ namespace ColesStopAndShop
                         if ((ItemId)itemScanned == itemId)
                         {
                             listOfItems.Add((ItemId)itemScanned);
+                            break;
                         }
                     }
                 }

--- a/ColesStopAndShop/CashRegister.cs
+++ b/ColesStopAndShop/CashRegister.cs
@@ -220,9 +220,9 @@ namespace ColesStopAndShop
                 {
                     // This loop checks to verify the key exists in the pre-defined dictionary before adding it.
                     // No error message is thrown if non existent and nothing is added to list, just moves on to next item.
-                    foreach (int item in storeDeployedAt.AllItemsAtStore.Keys)
+                    foreach (ItemId itemId in storeDeployedAt.AllItemsAtStore.Keys)
                     {
-                        if (itemScanned == item)
+                        if ((ItemId)itemScanned == itemId)
                         {
                             listOfItems.Add((ItemId)itemScanned);
                         }

--- a/ColesStopAndShop/CashRegister.cs
+++ b/ColesStopAndShop/CashRegister.cs
@@ -218,7 +218,15 @@ namespace ColesStopAndShop
                 }
                 else
                 {
-                    listOfItems.Add((ItemId)itemScanned);
+                    // This loop checks to verify the key exists in the pre-defined dictionary before adding it.
+                    // No error message is thrown if non existent and nothing is added to list, just moves on to next item.
+                    foreach (int item in storeDeployedAt.AllItemsAtStore.Keys)
+                    {
+                        if (itemScanned == item)
+                        {
+                            listOfItems.Add((ItemId)itemScanned);
+                        }
+                    }
                 }
 
             } while (true);
@@ -244,13 +252,6 @@ namespace ColesStopAndShop
             }
             salesTaxCharged = subTotal * SalesTaxRate;
             total = subTotal + salesTaxCharged;
-
-            // Converts items to string for receipt.
-            List<string> itemsBoughtToString = new List<string>();
-            foreach (ItemId item in listOfItems)
-            {
-                itemsBoughtToString.Add(item.ToString());
-            }
 
             /*
              * Prints Receipt below 


### PR DESCRIPTION
No longer throws exception if wrong item id is entered.
Removed unneeded block of code that converts list items to list of strings.